### PR TITLE
Сохранение форматирования исходного текста

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,11 +18,11 @@
 			<div class='container'>
 				<div class="result">
 					<h2 class="headers">Stop words</h2>
-					<div class='result__stop'></div>
+					<pre class='result__stop'></pre>
 				</div>
 				<div class="result">
 					<h2 class="headers">Toxic words</h2>
-					<div class='result__toxic'></div>
+					<pre class='result__toxic'></pre>
 				</div>
 			</div>
 		</form>

--- a/src/style.css
+++ b/src/style.css
@@ -78,3 +78,12 @@ h2 {
     border:2px solid black;
     box-shadow: 2px 2px 0px 0px rgba(0,0,0,0.75);
 }
+
+pre {
+  overflow-x: auto;
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Заменил div на pre с поддержкой word-wrap, так не теряется форматирования исходного текста и проще читается. Вот сравнение до и после:

<img width="1106" alt="Screen Shot 2019-08-16 at 15 28 44" src="https://user-images.githubusercontent.com/31260/63167653-91e74600-c03a-11e9-8828-226df0ad6bd2.png">

<img width="1097" alt="Screen Shot 2019-08-16 at 15 28 34" src="https://user-images.githubusercontent.com/31260/63167659-99a6ea80-c03a-11e9-8ec0-795763283980.png">
